### PR TITLE
Fix incorrect iamDefPrivilege.Privileges struct field tag

### DIFF
--- a/main.go
+++ b/main.go
@@ -188,7 +188,7 @@ type mappingInfoItem struct {
 
 type iamDefService struct {
 	Prefix     string            `json:"prefix"`
-	Privileges []iamDefPrivilege `json"privileges"`
+	Privileges []iamDefPrivilege `json:"privileges"`
 }
 
 type iamDefPrivilege struct {


### PR DESCRIPTION
I was reading the implementation of iamlive (very nice idea!) to learn how it works. I noticed that the struct field tag for `iamDefService.Privileges` is not correct as the colon was missing.