### PR TITLE
Releases/GH Actions: Add arm64 to GOARCH release matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,12 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/386, linux/amd64, windows/386, windows/amd64, darwin/amd64 
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
         goos: [linux, windows, darwin]
-        goarch: ["386", amd64]
+        goarch: ["386", amd64, arm64]
         exclude:
         - goos: darwin
           goarch: "386"
+        - goos: windows
+          goarch: arm64
     steps:
     - uses: actions/checkout@v2
     - uses: iann0036/go-release-action@v1.14


### PR DESCRIPTION
Since this project already relies on Go 1.16 we can build Apple Silicon (M1) binaries for releases.

I've added `arm64` to the build matrix and excluded `windows/arm64` (not supported). This will lead to new releases with `{darwin,linux}/arm64` 🥳 

I've verified that the Apple Silicon builds works on my M1 Mac Mini. Because I'm unsure how this code signing thing works, I also cross compiled with `darwin/arm64` and tested the resulting binary on the M1.

Cross compiled to test (via Docker):

```
docker run --rm -v "$PWD":/app -w /app -e GOOS=darwin -e GOARCH=arm64 golang:1.16rc1 go build -v
[...]
```

Tested (on M1):

```
$ ./iamlive --help
Usage of ./iamlive:
  -fails-only
        when set, only failed AWS calls will be added to the policy
  -profile string
        use the specified profile when combined with --set-ini (default "default")
  -set-ini
        when set, the .aws/config file will be updated to use the CSM monitoring and removed when exiting
```

No extra step was required to allow the binary to run.