### PR TITLE
Add --aws-redirect-host cli arg to allow using Iamlive with Localstack

### DIFF
--- a/iamlivecore/proxy.go
+++ b/iamlivecore/proxy.go
@@ -165,7 +165,7 @@ func dumpReq(req *http.Request) {
 	fmt.Printf("%v\n", string(dump))
 }
 
-func createProxy(addr string) {
+func createProxy(addr string, awsRedirectHost string) {
 	err := loadCAKeys()
 	if err != nil {
 		log.Fatal(err)
@@ -187,6 +187,11 @@ func createProxy(addr string) {
 			}
 			body, _ = ioutil.ReadAll(req.Body)
 			handleAWSRequest(req, body, 200)
+
+			if awsRedirectHost != "" {
+				req.URL.Host = awsRedirectHost
+				req.Host = awsRedirectHost
+			}
 		} else if isAzureHostname && *providerFlag == "azure" {
 			if *debugFlag {
 				dumpReq(req)

--- a/iamlivecore/service.go
+++ b/iamlivecore/service.go
@@ -105,8 +105,8 @@ func parseConfig() {
 			if cfg.Section("").HasKey("force-wildcard-resource") {
 				forceWildcardResource, _ = cfg.Section("").Key("force-wildcard-resource").Bool()
 			}
-			if cfg.Section("").HasKey("aws-redire4ct") {
-				awsRedirectHost = cfg.Section("").Key("aws-redirect").String()
+			if cfg.Section("").HasKey("aws-redirect-host") {
+				awsRedirectHost = cfg.Section("").Key("aws-redirect-host").String()
 			}
 
 		}


### PR DESCRIPTION
--aws-redirect-host cli arg sets the endpoint to which all aws requests will be redirected.

This is intended to be used with localstack.  One would forward requests proxied through Iamlive to localstack rather than aws.  Iamlive outputs the Iam Policies bases on the AWS API requests and forwards to Localstack which builds the resources.

I have setup a repo showing how this could be accomplished using Docker proxying: https://github.com/rulio/iamlive-localstack/

That repo builds a version of Iamlive that includes this change.
